### PR TITLE
Add custom login UI and logic, NUS Consent Form, and waitlist for external users

### DIFF
--- a/leetnode/prisma/schema.prisma
+++ b/leetnode/prisma/schema.prisma
@@ -49,13 +49,15 @@ model VerificationToken {
 
 model User {
   id                     String                  @id @default(cuid())
-  nusnetId               String?                 @unique
   username               String                  @unique @default(cuid())
   email                  String                  @unique
   emailVerified          DateTime?
   isNewUser              Boolean                 @default(true)
   image                  String?
   role                   Role                    @default(USER)
+  name                   String?
+  nusnetId               String?
+  consentDate            DateTime?
   lastActive             DateTime                @default(now())
   loginStreak            Int                     @default(1)
   points                 Int                     @default(1)
@@ -82,6 +84,12 @@ enum Frequency {
   Fortnightly
   Monthly
   Never
+}
+
+model Waitlist {
+  email        String   @id
+  subscribed   Boolean? @default(true)
+  subscribedAt DateTime @default(now())
 }
 
 model Attempt {

--- a/leetnode/src/components/Navbar.tsx
+++ b/leetnode/src/components/Navbar.tsx
@@ -357,7 +357,7 @@ export default function Navbar({
               <Menu.Label c="yellow">NUS</Menu.Label>
               <Menu.Item
                 component={Link}
-                href="/welcome"
+                href="/consent"
                 icon={<IconLicense size={14} stroke={1.5} />}
                 color="yellow"
               >

--- a/leetnode/src/components/admin/Courses.tsx
+++ b/leetnode/src/components/admin/Courses.tsx
@@ -328,7 +328,7 @@ const Courses = () => {
 
   return (
     <>
-      <Container size="lg" py={!mobile ? "xl" : undefined}>
+      <Container size="lg">
         <Title order={2} align="center" mb="lg" className={classes.title}>
           Courses Details
         </Title>
@@ -356,11 +356,11 @@ const Courses = () => {
               },
 
               control: {
-                border: "0 !important",
+                border: "0",
               },
 
               labelActive: {
-                color: `${theme.white} !important`,
+                color: `${theme.white}`,
               },
             })}
             size={mobile ? "xs" : "md"}

--- a/leetnode/src/components/admin/Performance.tsx
+++ b/leetnode/src/components/admin/Performance.tsx
@@ -36,7 +36,6 @@ import {
   Text,
   Title,
 } from "@mantine/core";
-import { useMediaQuery } from "@mantine/hooks";
 import { Mastery, Topic } from "@prisma/client";
 import {
   IconChevronsDown,
@@ -62,8 +61,7 @@ ChartJS.register(
 ChartJS.defaults.font.size = 16;
 
 const Performance = () => {
-  const { theme, classes } = useStyles();
-  const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm}px)`);
+  const { classes } = useStyles();
 
   const [active, setActive] = useState("");
   const [userData, setUserData] = useState<UsersWithMasteriesAndAttemptsType>(
@@ -233,7 +231,7 @@ const Performance = () => {
 
   return (
     <ScrollArea>
-      <Container size="lg" py={!mobile ? "xl" : undefined}>
+      <Container size="lg">
         <Title order={2} align="center" mb="lg" className={classes.title}>
           User Performance
         </Title>

--- a/leetnode/src/components/admin/Settings.tsx
+++ b/leetnode/src/components/admin/Settings.tsx
@@ -468,7 +468,7 @@ const Settings = () => {
 
 export default Settings;
 
-const useStyles = createStyles((_theme, _params, getRef) => ({
+const useStyles = createStyles((theme, _params, getRef) => ({
   controls: {
     ref: getRef("controls"),
     transition: "opacity 150ms ease",
@@ -485,20 +485,20 @@ const useStyles = createStyles((_theme, _params, getRef) => ({
 
   control: {
     backgroundColor:
-      _theme.colorScheme === "dark"
-        ? _theme.fn.variant({
+      theme.colorScheme === "dark"
+        ? theme.fn.variant({
             variant: "light",
-            color: _theme.primaryColor,
+            color: theme.primaryColor,
           }).background
-        : _theme.fn.variant({
+        : theme.fn.variant({
             variant: "filled",
-            color: _theme.primaryColor,
+            color: theme.primaryColor,
           }).background,
     color:
-      _theme.colorScheme === "dark"
-        ? _theme.fn.variant({ variant: "light", color: _theme.primaryColor })
+      theme.colorScheme === "dark"
+        ? theme.fn.variant({ variant: "light", color: theme.primaryColor })
             .color
-        : _theme.fn.variant({ variant: "filled", color: _theme.primaryColor })
+        : theme.fn.variant({ variant: "filled", color: theme.primaryColor })
             .color,
   },
 }));

--- a/leetnode/src/components/auth/Login.tsx
+++ b/leetnode/src/components/auth/Login.tsx
@@ -1,0 +1,177 @@
+import axios from "axios";
+import { signIn } from "next-auth/react";
+import { Dispatch, SetStateAction, useState } from "react";
+import toast from "react-hot-toast";
+
+import {
+  ActionIcon,
+  Button,
+  Container,
+  Group,
+  LoadingOverlay,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  useMantineTheme,
+} from "@mantine/core";
+import { IconBrandGoogle, IconLogin, IconSpeakerphone } from "@tabler/icons";
+import { useMutation } from "@tanstack/react-query";
+
+export default function Login({
+  setLoginMenuOpened,
+}: {
+  setLoginMenuOpened: Dispatch<SetStateAction<boolean>>;
+}) {
+  const theme = useMantineTheme();
+
+  const [email, setEmail] = useState("");
+  const [emailLoginIsLoading, setEmailLoginIsLoading] = useState(false);
+
+  const emailSignIn = async (isNewUser?: boolean) => {
+    const res = await signIn("email", {
+      email,
+      redirect: false,
+      callbackUrl: isNewUser ? "/welcome" : undefined,
+    });
+    if (res?.error) {
+      toast.error(`${res.error}\n\nPlease contact support if this persists.`);
+    } else if (res?.ok) {
+      toast.success(
+        `Verification successful! Check your inbox and junk mail for the magic link!\n\nVerified:\n${email}`,
+        {
+          duration: 5000,
+        }
+      );
+      setEmail("");
+      setLoginMenuOpened(false);
+    }
+    setEmailLoginIsLoading(false);
+  };
+
+  const { mutate: handleEmailLogin } = useMutation({
+    mutationFn: () =>
+      axios.post<{
+        customToast: boolean;
+        emailAllowed: boolean;
+        isNewUser?: boolean;
+      }>(`/api/auth/isEmailAllowed?email=${email}`),
+    onSuccess: (data) => {
+      if (!data?.data.emailAllowed) {
+        toast.error(
+          "Unfortunately you are not authorized to access LeetNode without a valid invite. \n\nIn the meantime, you may join our waitlist or if you think this is a mistake, please contact support."
+        );
+        setEmailLoginIsLoading(false);
+      } else {
+        emailSignIn(data?.data.isNewUser);
+      }
+    },
+  });
+
+  const { mutate: handleJoinWaitlist } = useMutation({
+    mutationFn: () => axios.post(`/api/auth/joinWaitlist?email=${email}`),
+    onSuccess: (data) => {
+      if (data?.status === 201) {
+        setEmail("");
+        setLoginMenuOpened(false);
+      }
+      setEmailLoginIsLoading(false);
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        setEmailLoginIsLoading(true);
+        handleEmailLogin();
+      }}
+    >
+      <LoadingOverlay
+        visible={emailLoginIsLoading}
+        overlayBlur={1}
+        radius="md"
+      />
+      <Container p="sm">
+        <Stack spacing="sm">
+          <Title order={3}>
+            Welcome to{" "}
+            <Text
+              component="span"
+              variant="gradient"
+              gradient={{ from: theme.colors.cyan[5], to: "blue" }}
+            >
+              LeetNode
+            </Text>
+            !
+          </Title>
+          <TextInput
+            required
+            radius="md"
+            name="email"
+            type="email"
+            placeholder="Invite Email"
+            disabled={emailLoginIsLoading}
+            value={email}
+            onChange={(e) => setEmail(e.currentTarget.value.trim())}
+            error={email.length > 0 && !/^(.+)@(.+)$/.test(email)}
+            styles={{
+              input: {
+                backgroundColor:
+                  theme.colorScheme === "dark"
+                    ? theme.colors.dark[9]
+                    : theme.colors.gray[0],
+              },
+            }}
+          />
+          <Text size="xs" color="dimmed">
+            Enter the email address stated in your invite
+          </Text>
+          <Group position="apart">
+            <Group spacing="xs">
+              <Button
+                type="submit"
+                size="xs"
+                variant="outline"
+                color="gray"
+                radius="xl"
+                className="hover:bg-gray-50 dark:hover:bg-gray-900"
+                leftIcon={<IconLogin size={18} stroke={1.5} />}
+              >
+                Get Link
+              </Button>
+              <ActionIcon
+                size="md"
+                variant="outline"
+                color="gray"
+                radius="xl"
+                className="hover:bg-gray-50 dark:hover:bg-gray-900"
+                onClick={() => signIn("google")}
+              >
+                <IconBrandGoogle size={18} />
+              </ActionIcon>
+            </Group>
+            <Button
+              size="xs"
+              variant="light"
+              color="gray"
+              radius="md"
+              className="dark:bg-gray-900 dark:text-gray-300 dark:hover:bg-gray-800"
+              leftIcon={<IconSpeakerphone size={18} stroke={1.5} />}
+              onClick={() => {
+                if (email.length === 0 || !/^(.+)@(.+)$/.test(email)) {
+                  toast.error("Please enter a valid email address");
+                  return;
+                }
+                setEmailLoginIsLoading(true);
+                handleJoinWaitlist();
+              }}
+            >
+              Join Waitlist
+            </Button>
+          </Group>
+        </Stack>
+      </Container>
+    </form>
+  );
+}

--- a/leetnode/src/components/editor/QuestionViewer.tsx
+++ b/leetnode/src/components/editor/QuestionViewer.tsx
@@ -13,11 +13,12 @@ import {
   Divider,
   Flex,
   Modal,
+  Text,
   TextInput,
   Title,
   Tooltip,
 } from "@mantine/core";
-import { randomId, useDebouncedValue, useMediaQuery } from "@mantine/hooks";
+import { randomId, useDebouncedValue } from "@mantine/hooks";
 import { QuestionDifficulty } from "@prisma/client";
 import { IconEye, IconRefresh, IconSearch } from "@tabler/icons";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -33,7 +34,6 @@ enum QuestionDifficultyEnum {
 
 export default function QuestionViewer() {
   const { theme, classes } = useStyles();
-  const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm}px)`);
   const queryClient = useQueryClient();
 
   const editorHtml = useRef("");
@@ -107,7 +107,7 @@ export default function QuestionViewer() {
   }, [page, questions, sortStatus, debouncedQuery]);
 
   return (
-    <Container size="lg" py={!mobile ? "xl" : undefined}>
+    <Container size="lg">
       <Title order={2} className={classes.title} align="center" mb="sm">
         All Questions
       </Title>
@@ -122,7 +122,6 @@ export default function QuestionViewer() {
       <Button
         fullWidth
         variant="default"
-        color="gray"
         radius="sm"
         mb="lg"
         onClick={() => {
@@ -130,7 +129,9 @@ export default function QuestionViewer() {
           editorHtml.current = "";
         }}
       >
-        + Add New Question
+        <Text className="text-gray-800 dark:text-gray-300">
+          + Add New Question
+        </Text>
       </Button>
 
       <Flex mb="xs" align="center" gap="md">
@@ -160,7 +161,7 @@ export default function QuestionViewer() {
 
       <DataTable
         idAccessor="questionTitle"
-        height={320}
+        height="calc(100vh - 380px)"
         withBorder
         highlightOnHover
         borderRadius="sm"

--- a/leetnode/src/components/forms/Consent.tsx
+++ b/leetnode/src/components/forms/Consent.tsx
@@ -1,0 +1,190 @@
+export default function Consent() {
+  return (
+    <div className="prose-sm">
+      <ol>
+        <li>
+          <h4>Protocol title</h4>
+          <p>
+            Early Identification and Intervention to Help Students Cope with an
+            Electrical Engineering Module
+          </p>
+        </li>
+        <li>
+          <h4>Principal Investigator and Co-Investigator(s)</h4>
+          <ul>
+            <li>
+              PI:
+              <ul>
+                <li>Assoc. Prof. Soh Wee Seng</li>
+                <li>Dept of Electrical & Computer Engineering, NUS</li>
+                <li>Tel: 6516-5766</li>
+              </ul>
+            </li>
+            <li>
+              Co-I:
+              <ul>
+                <li>Dr. Chua Dingjuan</li>
+                <li>Dept of Electrical & Computer Engineering, NUS</li>
+                <li>Tel: 6516-8889</li>
+              </ul>
+            </li>
+            <li>
+              Co-I:
+              <ul>
+                <li>Assoc. Prof. Heng Chun Huat</li>
+                <li>Dept of Electrical & Computer Engineering, NUS</li>
+                <li>Tel: 6516-1628</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <h4>What is the purpose of this research?</h4>
+          <p>
+            You are invited to participate in a research study. This information
+            sheet provides you with information about the research study. The
+            Principal Investigator (the person in charge of this research) or
+            his/her representative will also describe this research to you and
+            answer all of your questions. Read the information below and ask
+            questions about anything you don&apos;t understand before deciding
+            whether or not to take part.
+          </p>
+          <p>
+            In this research project, we provide an adaptive learning software
+            to help students bridge their knowledge gap in electrical circuit
+            principles that could hinder their performance in EE2027. We
+            investigate the relationship between the mastery level they attain
+            for each topic and their performance in EE1111A, EE2111A, and EE2027
+            so that we can help the students better.
+          </p>
+        </li>
+        <li>
+          <h4>Who can participate in the research?</h4>
+          <p>
+            What is the expected duration of my participation? What is the
+            duration of this research? Only students taking EE1111A, EE2111A,
+            and EE2027 can participate in the research. If you agree to take
+            part, your participation will last until you successfully complete
+            EE2027. The entire research project will conclude on 31 Jan 2026.
+          </p>
+        </li>
+        <li>
+          <h4>
+            What is the approximate number of research participants involved?
+          </h4>
+          <p>
+            Three EE cohorts of about 600 students in total will be invited to
+            participate in this study. The actual number of participants depend
+            on the response rate.
+          </p>
+        </li>
+        <li>
+          <h4>What will be done if I take part in this research study?</h4>
+          <p>
+            If you take part in this research study, we will study the
+            relationship between the mastery scores you attain for each topic
+            and your performance in EE1111A, EE2111A, and EE2027.
+          </p>
+        </li>
+        <li>
+          <h4>
+            How will my privacy and the confidentiality of my research records
+            be protected?
+          </h4>
+          <p>
+            Only the Principal Investigator knows that you have opted to
+            participate in this research, and will collect your name, student
+            number, and intake academic year for the purpose of studying the
+            relationship between your log data (e.g., mastery scores) and your
+            performance in the three modules. Your module lecturers from
+            EE1111A, EE2111A, and EE2027 will not know whether you have opted to
+            participate in this research. Your personal data will never be used
+            in a publication or presentation. All identifiable data will be
+            discarded at the end of the semester when you have completed EE2027.
+          </p>
+        </li>
+        <li>
+          <h4>What are the possible risks for participants?</h4>
+          <p>There is no foreseeable risk for participants.</p>
+        </li>
+        <li>
+          <h4>Will there be reimbursement for participation?</h4>
+          <p>
+            There is no reimbursement for participating in this research; we
+            rely 100% on your goodwill.
+          </p>
+        </li>
+        <li>
+          <h4>What are the possible benefits to me and to others?</h4>
+          <p>
+            There is no direct benefit to you. The knowledge gained would
+            benefit future students taking similar modules in NUS, as well as
+            other tertiary institutions around the world, as a result of any
+            publication resulting from this study.
+          </p>
+        </li>
+        <li>
+          <h4>Can I refuse to participate in this research?</h4>
+          <p>
+            Yes, you can. Your decision to participate in this research study is
+            voluntary and completely up to you. You can also withdraw from the
+            research at any time without giving any reasons, by informing the
+            principal investigator and all your personal data will be discarded.
+          </p>
+        </li>
+        <li>
+          <h4>Whom should I call if I have any questions or problems?</h4>
+          <p>
+            Please contact the Principal Investigator&apos;s research assistant,
+            [Zac, <code>e0426185@u.nus.edu</code>] for all research-related
+            matters. Your inquiries will be anonymized before they are forwarded
+            to the Principal Investigator for a response.
+          </p>
+          <p>
+            For an independent opinion specifically regarding the rights and
+            welfare of research participants, you may contact a LACE member at
+            LACE-DERC@nus.edu.sg.
+          </p>
+        </li>
+      </ol>
+      <br />
+      <h4>
+        <u>Electronic Consent Form</u>
+      </h4>
+      <p>
+        <strong>Protocol title:</strong> Early Identification and Intervention
+        to Help Students Cope with an Electrical Engineering Module
+      </p>
+      <strong>
+        Principal Investigator with the contact number and organization:
+      </strong>
+      <p>
+        Associate Professor Soh Wee Seng, Tel: 6516-5766, Dept of Electrical and
+        Computer Engineering, National University of Singapore
+      </p>
+      <p>
+        <strong>
+          By completing and submitting this electronic form, I hereby
+          acknowledge that:
+        </strong>
+      </p>
+      <ol>
+        <li>I have agreed to take part in the above research. </li>
+        <li>
+          I have read through the above information sheet that explains the use
+          of my log data for the purpose of studying the relationship between
+          the mastery scores I attain for each topic and my performance in
+          EE1111A, EE2111A, and EE2027.
+        </li>
+        <li>
+          I can withdraw from the research at any point of time by informing the
+          Principal Investigator and all my personal data will be discarded.
+        </li>
+        <li>
+          I will not have any financial benefits that result from the commercial
+          development of this research.
+        </li>
+      </ol>
+    </div>
+  );
+}

--- a/leetnode/src/components/user/statistics/MasteryBar.tsx
+++ b/leetnode/src/components/user/statistics/MasteryBar.tsx
@@ -197,7 +197,7 @@ export default function MasteryBar({ data }: TableSortProps) {
 
 const useStyles = createStyles((theme) => ({
   th: {
-    padding: "0 !important",
+    padding: "0",
   },
 
   control: {

--- a/leetnode/src/middleware.ts
+++ b/leetnode/src/middleware.ts
@@ -3,16 +3,26 @@ import { NextResponse } from "next/server";
 
 import { Role } from "@prisma/client";
 
-export default withAuth(function middleware(req) {
-  // Redirect if they don't have the allowed role
-  if (
-    req.nextUrl.pathname.includes("admin") &&
-    req.nextauth.token?.role !== Role.SUPERUSER &&
-    req.nextauth.token?.role !== Role.ADMIN
-  ) {
-    return NextResponse.redirect(new URL("/403", req.url));
+export default withAuth(
+  function middleware(req) {
+    // Redirect if they don't have the allowed role
+    if (
+      req.nextUrl.pathname.includes("admin") &&
+      req.nextauth.token?.role !== Role.SUPERUSER &&
+      req.nextauth.token?.role !== Role.ADMIN
+    ) {
+      return NextResponse.redirect(new URL("/403", req.url));
+    }
+  },
+  {
+    pages: {
+      // Custom redirect all auth to homepage and send notifications instead
+      signIn: "/",
+      error: "/",
+      verifyRequest: "/",
+    },
   }
-});
+);
 
 export const config = {
   matcher: [

--- a/leetnode/src/pages/api/auth/[...nextauth].ts
+++ b/leetnode/src/pages/api/auth/[...nextauth].ts
@@ -90,7 +90,7 @@ export const authOptions: NextAuthOptions = {
     error: "/",
     verifyRequest: "/",
     // New user redirect doesn't work for email provider as we add whitelisted emails into the User table, causing the new users to not be counted as new users
-    newUser: "/welcome",
+    newUser: "/consent",
   },
   session: {
     strategy: "jwt",

--- a/leetnode/src/pages/api/auth/isEmailAllowed.ts
+++ b/leetnode/src/pages/api/auth/isEmailAllowed.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { prisma } from "@/server/db/client";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const isEmailAllowed = await prisma.user.findFirst({
+    where: {
+      email: req.query.email as string,
+    },
+    select: {
+      email: true,
+      isNewUser: true,
+    },
+  });
+
+  res.status(200).json({
+    customToast: true,
+    emailAllowed: isEmailAllowed !== null,
+    isNewUser: isEmailAllowed?.isNewUser,
+  });
+}

--- a/leetnode/src/pages/api/auth/joinWaitlist.ts
+++ b/leetnode/src/pages/api/auth/joinWaitlist.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { prisma } from "@/server/db/client";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const isEmailAllowed = await prisma.user.findFirst({
+    where: {
+      email: req.query.email as string,
+    },
+  });
+
+  if (isEmailAllowed) {
+    return res.status(200).json({
+      message: "Email already invited, please check your inbox and junk mail!",
+      customIcon: "📫",
+      addedToWaitlist: false,
+    });
+  }
+
+  await prisma.waitlist.upsert({
+    where: {
+      email: req.query.email as string,
+    },
+    update: {},
+    create: {
+      email: req.query.email as string,
+    },
+  });
+
+  res.status(201).json({
+    message: "Added to waitlist!",
+    customIcon: "🎉",
+    addedToWaitlist: true,
+  });
+}

--- a/leetnode/src/pages/api/user/admin/edit.ts
+++ b/leetnode/src/pages/api/user/admin/edit.ts
@@ -33,11 +33,20 @@ export default async function handler(
       where: {
         email: req.query.email as string,
       },
-      data: {
-        username: req.body.username,
-        role: req.body.role,
-        points: parseInt(req.body.points),
-      },
+      data: req.body.revokeConsent
+        ? {
+            username: req.body.username,
+            role: req.body.role,
+            points: parseInt(req.body.points),
+            consentDate: null,
+            name: null,
+            nusnetId: null,
+          }
+        : {
+            username: req.body.username,
+            role: req.body.role,
+            points: parseInt(req.body.points),
+          },
     });
   } catch (error) {
     console.error(error);

--- a/leetnode/src/pages/api/user/admin/sendRecruitmentEmails.ts
+++ b/leetnode/src/pages/api/user/admin/sendRecruitmentEmails.ts
@@ -24,42 +24,42 @@ export const sendRecruitmentEmail = async (emails: string[]) => {
           "Invitation to Use an Adaptive Learning Software to Bridge Electrical Circuit Knowledge Gaps",
         text: `
           Dear Student,
-      
+
           Each year, a significant number of students perform poorly in EE2027 as a result of knowledge gaps in electrical circuit principles covered in EE1111A and EE2111A.  We believe that many of these students would benefit from early detection and intervention to bridge their knowledge gaps.
-      
+
           We have developed an adaptive learning software to help bridge any potential knowledge gaps.  You are encouraged to use the software to test and improve your knowledge in relevant electrical circuit principles until you have attained a "mastery score" of at least 80% for every topic.
-      
+
           The software can be accessed via https://leetnode.vercel.app
-          
+
           Your login email is as follows: ${email}
-      
+
           Upon entering your email address, you will be sent a magic link, likely in your junk folder. Click on the email's magic link to sign in, no passwords required. However, please feel free to change your username after logging in.
-      
+
           Upon logging in, we will request for your consent to allow your software's usage log data to be available for research purposes, and also to link these log data to your performance in EE1111A, EE2111A, and EE2027. To protect your privacy, your lecturers for the above modules will not know whether you have agreed to participate in this research study; only the Principal Investigator (i.e., me), who does not teach the above three modules, will have this information.
-      
+
           While you will be able to use the software without providing the above consent, the insights gained from our research study could potentially benefit future students taking similar modules in NUS, and beyond.  
           Thank you very much for your help and support.
-      
+
           Thanks and regards,
           Assoc. Prof. Soh Wee Seng
         `,
         html: `
           <p>Dear Student,</p>
-      
+
           <p>Each year, a significant number of students perform poorly in EE2027 as a result of knowledge gaps in electrical circuit principles covered in EE1111A and EE2111A.  We believe that many of these students would benefit from early detection and intervention to bridge their knowledge gaps.</p>
-      
+
           <p>We have developed an adaptive learning software to help bridge any potential knowledge gaps.  You are encouraged to use the software to test and improve your knowledge in relevant electrical circuit principles until you have attained a "mastery score" of at least 80% for every topic.</p>
-      
+
           <p>The software can be accessed via <a href="https://leetnode.vercel.app" target="_blank">https://leetnode.vercel.app</a></p>
-          
+
           <p>Your login email is as follows: <u>${email}</u></p>
-      
+
           <p>Upon entering your email address, you will be sent a magic link, likely in your junk folder. Click on the email's magic link to sign in, no passwords required. However, please feel free to change your username after logging in.</p>
-      
+
           <p>Upon logging in, we will request for your consent to allow your software's usage log data to be available for research purposes, and also to link these log data to your performance in EE1111A, EE2111A, and EE2027. To protect your privacy, your lecturers for the above modules will not know whether you have agreed to participate in this research study; only the Principal Investigator (i.e., me), who does not teach the above three modules, will have this information.</p>
-      
+
           <p>While you will be able to use the software without providing the above consent, the insights gained from our research study could potentially benefit future students taking similar modules in NUS, and beyond. Thank you very much for your help and support.</p>
-      
+
           <p>Thanks and regards,</p>
           <p>Assoc. Prof. Soh Wee Seng</p>
         `,

--- a/leetnode/src/pages/consent.tsx
+++ b/leetnode/src/pages/consent.tsx
@@ -26,7 +26,7 @@ import { DatePicker } from "@mantine/dates";
 import { useMediaQuery } from "@mantine/hooks";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
-export default function WelcomePage() {
+export default function ConsentPage() {
   const theme = useMantineTheme();
   const mobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm}px)`);
 

--- a/leetnode/src/pages/dashboard.tsx
+++ b/leetnode/src/pages/dashboard.tsx
@@ -1,6 +1,6 @@
 import User from "@/components/user/User";
 
-export default function Dashboard() {
+export default function DashboardPage() {
   // KIV: Add Prof page and render base on ROLE
   return <User />;
 }

--- a/leetnode/src/pages/index.tsx
+++ b/leetnode/src/pages/index.tsx
@@ -15,7 +15,7 @@ import {
   Title,
 } from "@mantine/core";
 
-export default function Home() {
+export default function HomePage() {
   const { classes, theme } = useStyles();
 
   return (

--- a/leetnode/src/pages/test.tsx
+++ b/leetnode/src/pages/test.tsx
@@ -59,7 +59,7 @@ const tabs = {
   ],
 };
 
-export default function Test() {
+export default function TestPage() {
   const { theme, classes, cx } = useStyles();
   const [section, setSection] = useState<"account" | "general">("account");
   const [active, setActive] = useState("Editor");


### PR DESCRIPTION
- NUS Consent Forms for user data collection on first login and in navbar
- Custom login modal UI in home page
- Custom redirect next-auth pages to home page to show toast/notif instead of standalone pages for: signin, error, verify-user
- Waitlist to collect emails of non-invited users since this app is by exclusive whitelist for now
- Change new user login page and name from /welcome to /consent for the data consent form